### PR TITLE
Saving a ton of ram?

### DIFF
--- a/src/voodoospark.cpp
+++ b/src/voodoospark.cpp
@@ -92,7 +92,7 @@ char myIpString[32];
 
 void setup() {
   server.begin();
-  //netapp_ipconfig(&ip_config);
+  netapp_ipconfig(&ip_config);
   if (DEBUG) {
     Serial.begin(115200);
   }


### PR DESCRIPTION
If we drop the servo objects for which we don't have pins, we save a ton of ram, and the blink example works again! :)
