### PR TITLE
Enable A7 for PWM

### DIFF
--- a/src/voodoospark.cpp
+++ b/src/voodoospark.cpp
@@ -68,7 +68,7 @@ int ToServoIndex(int pin) {
   // A5
   if (pin == 15) return 4;
   // A7
-  if (pin == 17) return 6;
+  if (pin == 17) return 5;
 }
 
 


### PR DESCRIPTION
Not only does it work , but also it is needed for using the Spark ["Shield Shield"](https://github.com/spark/docs/blob/master/docs/shields.md#shield-shield) with a L298P motor shield with the default jumper configuration.

I knew that Spark Core supported, due to testing their RC car sketch. After some further experimentation, I determined by testing my hardware setup that is was in fact supported by the hardware.

I will be making an associated PR against https://github.com/rwaldron/spark-io with the required change to relax the validation on that side.
