### PR TITLE
Switch from deprecated Network class to newer WiFi class

### DIFF
--- a/src/voodoospark.cpp
+++ b/src/voodoospark.cpp
@@ -312,7 +312,7 @@ void setup() {
   Serial.begin(115200);
   #endif
 
-  IPAddress myIp = Network.localIP();
+  IPAddress myIp = WiFi.localIP();
   static char myIpString[24] = "";
   char octet[5];
   itoa(myIp[0],octet,10); strcat(myIpString,octet); strcat(myIpString,".");


### PR DESCRIPTION
The current Spark cloud has removed the `Network` class, and replaced it with the `WiFi` class. This prevented the Voodoospark code from being compiled on the Spark cloud, due to resulting errors.

This small change allows the code to compile, and appears to work nicely with our other existing code that calls Voodoo.
