### PR TITLE
fixed buffer overflow and allow unused bytes to be kept for the next action

### DIFF
--- a/firmware/voodoospark.cpp
+++ b/firmware/voodoospark.cpp
@@ -329,9 +329,9 @@ void processInput() {
   #ifdef DEBUG
   Serial.println("----------processInput----------");
   Serial.print("Bytes Available: ");
-  Serial.println(available, DEC);
+  Serial.println(bytesRead, DEC);
 
-  for (i = 0; i < available; i++) {
+  for (i = 0; i < bytesRead; i++) {
     Serial.print(i, DEC);
     Serial.print(": ");
     Serial.println(buffer[i], DEC);
@@ -728,9 +728,8 @@ void loop() {
       // Move all available bytes into the buffer,
       // this avoids building up back pressure in
       // the client byte stream.
-      for (int i = 0; i < available; i++) {
-        buffer[i] = client.read();
-        bytesRead++;
+      for (int i = 0; i < available && i < 16-bytesRead; i++) {
+        buffer[bytesRead++] = client.read();
       }
 
       #ifdef DEBUG


### PR DESCRIPTION
1. Fixes buffer overflow in the loop which reads data `client.read()` into the buffer. Now the loop will stop reading if the `buffer` full.
2. If after processing all bytes of data, there still are bytes remaining (unused bytes), these are left at the beginning of the `buffer` to be used in the next `processInputs`
