### PR TITLE
All references to spark-io should now be particle-io

### DIFF
--- a/firmware/examples/blink.js
+++ b/firmware/examples/blink.js
@@ -1,7 +1,7 @@
-var Spark = require("../../spark-io");
-var board = new Spark({
-  token: process.env.SPARK_TOKEN,
-  deviceId: process.env.SPARK_DEVICE_ID
+var Particle = require("../../particle-io");
+var board = new Particle({
+  token: process.env.PARTICLE_TOKEN,
+  deviceId: process.env.PARTICLE_DEVICE_ID
 });
 
 board.on("ready", function() {

--- a/firmware/examples/j5-servo.js
+++ b/firmware/examples/j5-servo.js
@@ -1,9 +1,9 @@
 var five = require("../../johnny-five");
-var Spark = require("../../spark-io");
+var Particle = require("../../particle-io");
 var board = new five.Board({
-    io: new Spark({
-        token: process.env.SPARK_TOKEN,
-        deviceId: process.env.SPARK_DEVICE_ID
+    io: new Particle({
+        token: process.env.PARTICLE_TOKEN,
+        deviceId: process.env.PARTICLE_DEVICE_ID
     })
 });
 

--- a/firmware/examples/pawelbot.js
+++ b/firmware/examples/pawelbot.js
@@ -1,11 +1,11 @@
 var five = require("johnny-five");
-var Spark = require("../../spark-io");
+var Particle = require("../../particle-io");
 var keypress = require('keypress');
 
 var board = new five.Board({
-    io: new Spark({
-        token: process.env.SPARK_TOKEN,
-        deviceId: process.env.SPARK_DEVICE_ID
+    io: new Particle({
+        token: process.env.PARTICLE_TOKEN,
+        deviceId: process.env.PARTICLE_DEVICE_ID
     })
 });
 

--- a/firmware/examples/servo.js
+++ b/firmware/examples/servo.js
@@ -1,7 +1,7 @@
-var Spark = require("../../spark-io");
-var board = new Spark({
-    token: process.env.SPARK_TOKEN,
-    deviceId: process.env.SPARK_DEVICE_ID
+var Particle = require("../../particle-io");
+var board = new Particle({
+    token: process.env.PARTICLE_TOKEN,
+    deviceId: process.env.PARTICLE_DEVICE_ID
 });
 
 

--- a/firmware/voodoospark.cpp
+++ b/firmware/voodoospark.cpp
@@ -5,7 +5,7 @@
   * @version V2.7.2
   * @date    16-June-2015
   * @brief   Exposes the firmware level API through a TCP Connection initiated
-  *          to the spark device
+  *          to the Particle devices (Core and Photon)
   ******************************************************************************
   Copyright (c) 2015 Chris Williams (voodootikigod)  All rights reserved.
 
@@ -189,7 +189,7 @@ unsigned long SerialSpeed[] = {
  */
 Servo servos[8];
 /*
-  The Spark board can only support PWM/Servo on specific pins, so
+  The Particle devices can only support PWM/Servo on specific pins, so
   based on the pin number, determine the servo index for the allocated
   servo object.
  */
@@ -527,7 +527,7 @@ void processInput() {
         Serial.println(sampleInterval, DEC);
         #endif
 
-        // Lower than ~100ms will likely crash the spark,
+        // Lower than ~100ms will likely crash the device,
         // but
         if (sampleInterval < 20) {
           sampleInterval = 20;
@@ -838,7 +838,7 @@ void loop() {
 
 
     // Reporting must be limited to every ~100ms
-    // Otherwise the spark becomes unreliable and
+    // Otherwise the device becomes unreliable and
     // exhibits a higher crash frequency.
     nowms = millis();
     if (nowms - lastms > sampleInterval && reporters > 0) {

--- a/particle.json
+++ b/particle.json
@@ -3,5 +3,5 @@
   "author": "Chris Williams <voodootikigod@gmail.com>",
   "license": "MIT",
   "version": "2.7.2",
-  "description": "TCP enabled IO protocol for Spark Core communication"
+  "description": "TCP enabled IO protocol for Spark Device (Core, Photon) communication"
 }

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ With your Particle device connected to a Wifi network and has already gone throu
 5.  Once the flashing process is complete, close the Particle.io Editor.
 
 
-Alternately, the firmware may be loaded using the Particle CLI ([particle-cli](https://github.com/particle/particle-cli)) instead of the Particle.io Editor:
+Alternately, the firmware may be loaded using the Particle CLI ([particle-cli](https://github.com/spark/particle-cli)) instead of the Particle.io Editor:
 
 ``` bash
 npm install -g particle-cli

--- a/readme.md
+++ b/readme.md
@@ -1,38 +1,38 @@
 ## What is VoodooSpark?
 
-VoodooSpark is a customized firmware build for the [Spark Core device](https://www.spark.io) to allow a remote interface definition of the firmware API over a local TCP connection. The intent is to allow client-side programs to directly control the Spark Core in real-time regardless of their programming language. The interface exposed is directly mapped to the one provided by Spark available in their [docs section](https://docs.spark.io/).
+VoodooSpark is a customized firmware build for the [Particle devices](https://www.particle.io) (Core and Photon) to allow a remote interface definition of the firmware API over a local TCP connection. The intent is to allow client-side programs to directly control the Particle devices in real-time regardless of their programming language. The interface exposed is directly mapped to the one provided by Particle available in their [docs section](https://docs.particle.io/).
 
-The VoodooSpark uses the [Spark Cloud](http://docs.spark.io/#/start/wait-what-is-this-thing-the-spark-cloud) and its REST API to provide IP address and port information to the local spark core. It will then initiate a direct connection to the host machine, on which will need to be a TCP server. Once the connection has been made, the host machine can drive the Spark Core using the binary protocol defined below to effectively execute firmware API level commands dynamically.
+The VoodooSpark uses the [Particle Cloud](https://www.particle.io/prototype) and its REST API to provide IP address and port information to the local Particle device. It will then initiate a direct connection to the host machine, on which will need to be a TCP server. Once the connection has been made, the host machine can drive the Particle device using the binary protocol defined below to effectively execute firmware API level commands dynamically.
 
 ## Loading the Firmware
 
-With your Spark device connected to a Wifi network and has already gone through the ["claim"/ownership process](http://docs.spark.io/#/start/step-1-power-the-core):
+With your Particle device connected to a Wifi network and has already gone through the [connection process](https://docs.particle.io/guide/getting-started/connect/photon/#connecting-your-device):
 
-1.  Open the [Spark.io Editor](https://www.spark.io/build) with the credentials used when going through the claiming process.
+1.  Open the [Particle.io Editor](https://www.particle.io/build) with the credentials used when going through the connection process.
 2.  Copy and paste the entire contents of [firmware/voodoospark.cpp](https://raw.githubusercontent.com/voodootikigod/voodoospark/master/firmware/voodoospark.cpp) into the editor window.
 3.  Click "Verify"
 4.  Click "Flash"
-5.  Once the flashing process is complete, close the Spark.io Editor.
+5.  Once the flashing process is complete, close the Particle.io Editor.
 
 
-Alternately, the firmware may be loaded using the Spark CLI ([spark-cli](https://github.com/spark/spark-cli)) instead of the Spark.io Editor:
+Alternately, the firmware may be loaded using the Particle CLI ([particle-cli](https://github.com/particle/particle-cli)) instead of the Particle.io Editor:
 
 ``` bash
-npm install -g spark-cli
-spark cloud login
-spark cloud flash SPARK_DEVICE_ID firmware/voodoospark.cpp
+npm install -g particle-cli
+particle cloud login
+particle cloud flash PARTICLE_DEVICE_ID firmware/voodoospark.cpp
 ```
 
 
-Now your Spark Core is running VoodooSpark, lets connect to it!
+Now your Particle device is running VoodooSpark, lets connect to it!
 
-## Connecting the Spark Core to You!
+## Connecting the Particle device to You!
 
-The way VoodooSpark works is to use the Spark Cloud as a channel to identify where to initiate the TCP connection to the Spark Device from your host machine.
+The way VoodooSpark works is to use the Particle Cloud as a channel to identify where to initiate the TCP connection to the Particle Device from your host machine.
 
-In order to connect the Spark Core to your computer, you will first need to issue an HTTP GET request to the Spark Cloud. This can be done via any programming language, but for this example we are using a simple CURL command. You will need some information outlined with curly braces below, please note the {DEVICE-ID} and {ACCESS-TOKEN} are available from the [Spark.io Editor](https://www.spark.io/build)
+In order to connect the Particle device to your computer, you will first need to issue an HTTP GET request to the Particle Cloud. This can be done via any programming language, but for this example we are using a simple CURL command. You will need some information outlined with curly braces below, please note the {DEVICE-ID} and {ACCESS-TOKEN} are available from the [Particle.io Editor](https://www.particle.io/build)
 
-    curl https://api.spark.io/v1/devices/{DEVICE-ID}/endpoint?access_token={ACCESS-TOKEN}
+    curl https://api.particle.io/v1/devices/{DEVICE-ID}/endpoint?access_token={ACCESS-TOKEN}
 
 This should return a JSON document that looks similar to this:
 
@@ -48,14 +48,14 @@ This should return a JSON document that looks similar to this:
       }
     }
 
-The "result" value is the IP address of the Spark Device on your local network and the part after the colon (:) is the port that the server is currently listening on. This port will by default be 48879 (0xBEEF), but can be changed in the voodoospark firmware. Please do not hardcode the port for this reason, rather use the data returned back as the response.
+The "result" value is the IP address of the Particle Device on your local network and the part after the colon (:) is the port that the server is currently listening on. This port will by default be 48879 (0xBEEF), but can be changed in the voodoospark firmware. Please do not hardcode the port for this reason, rather use the data returned back as the response.
 
 With the IP Address and TCP port information, use your favorite language or TCP client to connect to the device (even telnet will work) and send it the necessary BINARY protocol commands to trigger the desired API interactions as defined in our [API Command guide](http://voodoospark.me/#api).
 
 
 ## How to Debug
 
-In case you want to see what is going inside the VoodooSpark in real-time, we have built in a lot of debug hooks for you. You will need a USB cable and the `screen` or `minicom` utilities (one of them) on unix. Modify the firmware loaded in the spark build system to convert the line:
+In case you want to see what is going inside the VoodooSpark in real-time, we have built in a lot of debug hooks for you. You will need a USB cable and the `screen` or `minicom` utilities (one of them) on unix. Modify the firmware loaded in the particle build system to convert the line:
 
     #define DEBUG 0
 
@@ -63,7 +63,7 @@ to the following definition:
 
     #define DEBUG 1
 
-This will enable debug mode, boot a serial port connection on the Spark and present on your computer for you to watch the inside voodoo. Be sure to flash the new firmware to your device, this is very important and easy to miss. Once the flashing finishes, do an
+This will enable debug mode, boot a serial port connection on the Particle device and present on your computer for you to watch the inside voodoo. Be sure to flash the new firmware to your device, this is very important and easy to miss. Once the flashing finishes, do an
 
     ls /dev
 
@@ -77,7 +77,7 @@ For screen this command will look like:
 
 ## Reference Implementations
 
-*   [Spark-io _node.js_](https://github.com/rwaldron/spark-io)
+*   [Particle-io _node.js_](https://github.com/rwaldron/particle-io)
 *   [Vspark _Go_](https://github.com/audreylim/vspark)
 
 ## License


### PR DESCRIPTION
In reference to issue https://github.com/voodootikigod/voodoospark/issues/43, this changes the branding from Spark to Particle.

**Note that I have not changed the name of this project.  It is still VoodooSpark**

1. Changed some existing references in code and readme to Particle
2. Updated the examples to use [particle-io](https://github.com/rwaldron/particle-io) (formerly spark-io)

I'm happy to re-brand the project if you want, but I don't know what you want to re-brand as.  VoodooParticle?  Voodoo?  VoodooFirmware?  Other ideas?